### PR TITLE
Restart workflow if an upload fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Github Actions Auto Build
 on:
   push:
     branches: [ "main" ]
+  repository_dispatch:
+    types: [ run_build ]
+
 
 env:
   BUILD_TYPE: Release
@@ -21,7 +24,6 @@ jobs:
           cd vdpm
           ./bootstrap-vitasdk.sh
           ./install-all.sh
-
 
       - name: Recompile vitaGL
         run: |
@@ -51,6 +53,14 @@ jobs:
           file: ${{github.workspace}}/build/VitaDB.zip
           overwrite: true
           tag: Nightly
+
+      - name: Restart workflow if an upload fails
+        if: ${{ failure() }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: restart
+          client-payload: '{"runid": "${{ github.run_id }}"}'
 
       - name: Get current date
         id: date


### PR DESCRIPTION
As mentioned by @Rinnegatamante,  Svenstaro action is prone to fail. To fix the problem, the auto-restart logic in [Yo Yo Loader Vita](https://github.com/Rinnegatamante/yoyoloader_vita) is adopted.